### PR TITLE
Import annotations from the __future__ package

### DIFF
--- a/alias/plugin.py
+++ b/alias/plugin.py
@@ -2,6 +2,7 @@
 
 An MkDocs plugin allowing links to your pages using a custom alias.
 """
+from __future__ import annotations
 
 import logging
 import re


### PR DESCRIPTION
Closes #9

This PR simply imports `annotations` from the` __future__` package in order to support newer type annotation syntax in Python 3.8.