### PR TITLE
Tests for "#17: do not fail when invalid aliases have an anchor, or invalid anchors"

### DIFF
--- a/test_plugin.py
+++ b/test_plugin.py
@@ -259,6 +259,75 @@ def test_replace_tag_with_anchor3():
     assert result == 'Test: [The Title](../../../my-alias.md#my anchor)'
 
 
+def test_replace_tag_shouldnt_break_alias_not_found():
+    """An alias that doesn't exist shouldn't break the plugin"""
+    logger = logging.getLogger()
+    aliases = {'my alias': {
+        'text': 'The Text',
+        'alias': 'my alias',
+        'url': 'my-alias.md'
+    }}
+    markdown = 'Test: [[unknown]]'
+    result = re.sub(
+        ALIAS_TAG_REGEX,
+        lambda match: replace_tag(match, aliases, logger, PAGE_FILE),
+        markdown
+    )
+    assert result == markdown
+
+
+def test_replace_tag_shouldnt_break_alias_not_found_with_anchor():
+    """An alias that doesn't exist shouldn't break the plugin"""
+    logger = logging.getLogger()
+    aliases = {'my alias': {
+        'text': 'The Text',
+        'alias': 'my alias',
+        'url': 'my-alias.md'
+    }}
+    markdown = 'Test: [[unknown#anchor]]'
+    result = re.sub(
+        ALIAS_TAG_REGEX,
+        lambda match: replace_tag(match, aliases, logger, PAGE_FILE),
+        markdown
+    )
+    assert result == markdown
+
+
+def test_replace_tag_shouldnt_break_alias_not_found_with_text():
+    """An alias that doesn't exist shouldn't break the plugin"""
+    logger = logging.getLogger()
+    aliases = {'my alias': {
+        'text': 'The Text',
+        'alias': 'my alias',
+        'url': 'my-alias.md'
+    }}
+    markdown = 'Test: [[unknown|Some bad reference]]'
+    result = re.sub(
+        ALIAS_TAG_REGEX,
+        lambda match: replace_tag(match, aliases, logger, PAGE_FILE),
+        markdown
+    )
+    assert result == markdown
+
+
+def test_replace_tag_shouldnt_break_alias_not_found_with_text_and_anchor():
+    """An alias that doesn't exist shouldn't break the plugin"""
+    logger = logging.getLogger()
+    aliases = {'my alias': {
+        'text': 'The Text',
+        'alias': 'my alias',
+        'url': 'my-alias.md'
+    }}
+    markdown = 'Test: [[unknown#anchor|Some bad reference]]'
+    result = re.sub(
+        ALIAS_TAG_REGEX,
+        lambda match: replace_tag(match, aliases, logger, PAGE_FILE),
+        markdown
+    )
+    assert result == markdown
+
+
+
 def test_plugin_shouldnt_break_with_text():
     """An alias with the word 'text' in it shouldn't break the plugin"""
     logger = logging.getLogger()
@@ -408,6 +477,32 @@ def test_plugin_should_link_to_anchor_on_current_page():
         page_file.content_string
     )
     assert result == 'Test: [Anchor](#anchor)\n\n## Anchor\n\nSome text'
+
+
+def test_plugin_should_not_break_on_anchor_not_found_on_current_page():
+    """An alias that doesn't exist shouldn't break the plugin"""
+    logger = logging.getLogger()
+    page_file = File(
+        'foo/bar.md',
+        src_dir=None,
+        dest_dir='/path/to/site',
+        use_directory_urls=False,
+    )
+    page_file.content_string = 'Test: [[#anchor]]\n\n## Anchor\n\nSome text'
+
+
+    aliases = {'my alias': {
+        'text': 'The Text',
+        'alias': 'my alias',
+        'url': 'my-alias.md'
+    }}
+    markdown = 'Test: [[#not-anchor]]'
+    result = re.sub(
+        ALIAS_TAG_REGEX,
+        lambda match: replace_tag(match, aliases, logger, page_file),
+        markdown
+    )
+    assert result == markdown
 
 
 def test_get_alias_names_1():


### PR DESCRIPTION
This PR adds some tests to check that the plugin doesn't break on invalid aliases with an anchor or invalid anchors.

Related:
- https://github.com/EddyLuten/mkdocs-alias-plugin/issues/17
- https://github.com/EddyLuten/mkdocs-alias-plugin/pull/18