### PR TITLE
Feature: allow reference syntax

### DIFF
--- a/alias/plugin.py
+++ b/alias/plugin.py
@@ -155,6 +155,8 @@ def replace_tag(
 
 
 def replace_reference(match, aliases, log, page_file):
+    """Callback used in the sub function within on_page_markdown for
+    reference-style links."""
     ref_id = match.group('ref_id')
     alias_name = match.group('alias_name')
 

--- a/test_plugin.py
+++ b/test_plugin.py
@@ -6,7 +6,14 @@ import logging
 import re
 
 from mkdocs.structure.files import File
-from alias.plugin import get_alias_names, get_page_title, replace_tag, replace_reference, ALIAS_TAG_REGEX, REFERENCE_REGEX
+from alias.plugin import (
+    get_alias_names,
+    get_page_title,
+    replace_tag,
+    replace_reference,
+    ALIAS_TAG_REGEX,
+    REFERENCE_REGEX,
+)
 
 PAGE_FILE = File("/folder1/folder4/folder5/test.md", "/src/", "/dest/", False)
 
@@ -450,8 +457,8 @@ def test_replace_reference():
     )
     assert result == '[alias]: ../../../my-alias.md'
 
-def test_replace_reference():
-    """reference syntax: alias with reference"""
+def test_replace_reference_anchor():
+    """reference syntax: alias with anchor"""
     logger = logging.getLogger()
     aliases = {'my alias': {
         'text': 'The Text',


### PR DESCRIPTION
This PR allows using referenced link syntax with aliases, as proposed in #16.

```md
The song references [Wuthering Heights][wuthering-heights].

[wuthering-heights]: [[wuthering-heights#references]]
```

Closes #16